### PR TITLE
bpo-37408: Precise that Tarfile "format" argument only concerns writing.

### DIFF
--- a/Doc/library/tarfile.rst
+++ b/Doc/library/tarfile.rst
@@ -290,9 +290,10 @@ be finalized; only the internally used file object will be closed. See the
 
       *fileobj* is not closed, when :class:`TarFile` is closed.
 
-   *format* controls the archive format. It must be one of the constants
+   *format* controls the archive format for writing. It must be one of the constants
    :const:`USTAR_FORMAT`, :const:`GNU_FORMAT` or :const:`PAX_FORMAT` that are
-   defined at module level.
+   defined at module level. When reading, format will be automatically detected, even
+   if different formats are present in a single archive.
 
    The *tarinfo* argument can be used to replace the default :class:`TarInfo` class
    with a different one.


### PR DESCRIPTION
According to https://bugs.python.org/issue30661#msg339300 , "format" argument of Tarfile.open() only concerns the writing of files. It's worth mentioning it in the doc, if it's True (confirmation from core maintainers is welcome).
